### PR TITLE
add copy-publishers-from private subcommand and use it

### DIFF
--- a/src/brand/attach
+++ b/src/brand/attach
@@ -139,148 +139,7 @@ noexecute=0
 
 unset inst_type
 
-# Get publisher information for global zone.  These structures are used
-# to store information about the global zone publishers and
-# incorporations.
-
-typeset -A gz_publishers
 typeset gz_incorporations=""
-
-#
-# Gather the zone publisher details. $1 is the location of the image we
-# are processing and $2 is an associative array used to store publisher
-# details.
-#
-gather_zone_publisher_details() {
-	STORED_IMAGE=$PKG_IMAGE
-	PKG_IMAGE=$1;export PKG_IMAGE
-	typeset -n publishers=$2
-	typeset -li publisher_count=0
-	typeset -li url_count=0
-	typeset line=
-	typeset name=
-	typeset mirror=
-	typeset origin=
-	typeset opublisher=
-	typeset first_preferred="true"
-
-	#
-	# Store publisher, origin and security details. It is assumed
-	# that mirrors all use the same key as the origins.
-	#
-	for line in $(get_publisher_urls all origin); do
-		print $line | IFS="=" read name origin
-		# When a publisher has multiple origins, the
-		# additional origins don't contain the publisher
-		# name. Correct for this by checking if origin is not
-		# set by get_publisher_urls() and, if so, use the
-		# "name" as the origin and set the name to the value
-		# we have already saved.
-		if [[ -z $origin ]]; then
-			origin=$name
-			name=${publisher.name}
-		elif [[ "$origin" == "None" ]]; then
-			# Publisher with no origins.
-			origin=""
-		fi
-
-		# Use a compound variable to store all the data
-		# relating to a publisher.
-		if [[ -z ${publishers[$name]} ]]; then
-			typeset -C publisher_$publisher_count
-			typeset -n publisher=publisher_$publisher_count
-			typeset publisher.sticky=""
-			typeset publisher.preferred=""
-			typeset publisher.enabled=""
-			typeset -a publisher.origins=""
-			typeset -a publisher.mirrors=""
-			typeset publisher.name=$name
-			typeset publisher.keyfile=""
-			typeset publisher.certfile=""
-			typeset publisher.sigpol=""
-
-			# Get the signature policy.  This code assumes
-			# specific output ( "signature-policy = <policy>"
-			# or empty-string).
-			publisher.sigpol=$($PKG publisher ${publisher.name} | \
-			    grep signature-policy | sed 's/ //g')
-
-			get_publisher_attrs ${publisher.name} origin | \
-			    IFS=" " read publisher.sticky publisher.preferred \
-			    publisher.enabled
-			# get_publisher_attrs doesn't actually set "preferred"
-			# anymore, as there is no "preferred" apart from the
-			# first one in the list.
-			publisher.preferred=$first_preferred
-			# From here on out, reset 'first_preferred' to false.
-			first_preferred="false"
-			if [[ -n "$origin" ]]; then
-				get_pub_secinfo ${publisher.name} | \
-				    read publisher.keyfile publisher.certfile
-				[[ ${publisher.keyfile} != "None" && \
-				    ! -f ${PKG_IMAGE}/${publisher.keyfile} ]] && \
-				    fail_usage "$f_nosuch_key" \
-				        ${publisher.keyfile}
-				[[ ${publisher.certfile} != "None" && \
-				    ! -f ${PKG_IMAGE}/${publisher.certfile} ]] && \
-				    fail_usage "$f_nosuch_cert" \
-				        ${publisher.certfile}
-			else
-				# Publisher has no origins.
-				publisher.keyfile="None"
-				publisher.certfile="None"
-			fi
-			publisher_count=publisher_count+1
-			url_count=0
-		fi
-		publisher.origins[$url_count]=$origin
-		publishers[$name]=${publisher}
-		url_count=url_count+1
-	done
-
-	#
-	# Store mirror details
-	#
-	url_count=0
-	for line in $(get_publisher_urls all mirror); do
-		print $line | IFS="=" read name mirror
-		if [[ -z $mirror ]]; then
-			mirror=$name
-			name=${publisher.name}
-		fi
-		if [[ -z $opublisher || $opublisher != $name ]]; then
-			opublisher=$name
-			eval publisher="${publishers[$name]}"
-			url_count=0
-		fi
-		publisher.mirrors[$url_count]=$mirror
-		publishers[$name]=${publisher}
-		url_count=url_count+1
-	done
-	
-	PKG_IMAGE=$STORED_IMAGE;export PKG_IMAGE
-}
-
-#
-# $1 is an associative array of publishers. Search this array and
-# return the preferred publisher.
-#
-get_preferred_publisher() {
-	typeset -n publishers=$1
-	typeset publisher=
-
-	for key in ${!publishers[*]}; do
-		eval publisher="${publishers[$key]}"
-
-		if [[ ${publisher.preferred}  ==  "true" ]]; then
-			print ${key}
-			return 0
-		fi
-
-	done
-	return 1
-}
-
 #
 # $1 is an empty string to be populated with a list of incorporation
 # fmris.
@@ -294,51 +153,6 @@ gather_incorporations() {
 	    ':pkg.depend.install-hold:core-os*');do
 		incorporations="$incorporations $(get_pkg_fmri $p)"
 	done
-}
-
-#
-# Print the pkg(1) command which defines a publisher. $1 is an associative 
-# array of publisher details and $2 is the publisher to be printed.
-#
-print_publisher_pkg_defn() {
-	typeset -n publishers=$1
-	typeset pname=$2
-	typeset publisher=
-	typeset args=""
-	typeset origin=
-	typeset mirror=
-
-	eval publisher="${publishers[$pname]}"
-
-	if [[ "${publisher.sigpol}" != "" ]]; then
-		args="$args --set-property ${publisher.sigpol}"
-	fi
-
-	if [[ ${publisher.preferred} == "true" ]]; then
-		args="$args -P"
-	fi
-
-	for origin in ${publisher.origins[*]}; do
-		args="$args -g $origin"
-	done
-
-	for mirror in ${publisher.mirrors[*]}; do
-		args="$args -m $mirror"
-	done
-
-	if [[ ${publisher.sticky} == "true" ]]; then
-		args="$args --sticky"
-	else
-		args="$args --non-sticky"
-	fi
-
-	if [[ ${publisher.enabled} == "true" ]]; then
-		args="$args --enable"
-	else
-		args="$args --disable"
-	fi
-
-	echo "$args"
 }
 
 # Other brand attach options are invalid for this brand.
@@ -528,29 +342,6 @@ echo $variant | IFS=" " read variantname variantval
 # Check that the variant is non-global, else fail
 [[ $variantval = "nonglobal" ]] || fatal "$f_sanity_global" $VARIANT $variantval
 
-# We would like to ensure that our NGZ publishers are a superset of
-# those in the GZ. We do this by building a list of all publishers in
-# the GZ. We then process this list in the NGZ, first removing (if
-# present) and then installing all publishers in this list. Other
-# publisher, i.e. those not in the GZ list, are left as is.
-
-#
-# Gather all the publisher details for the global zone
-#
-gather_zone_publisher_details $PKG_IMAGE gz_publishers
-
-#
-# Get the preferred publisher for the global zone
-# If we were not able to get the zone's preferred publisher, complain.
-#
-gz_publisher_pref=$(get_preferred_publisher gz_publishers)
-
-if [[ $? -ne 0 ]]; then
-	fail_usage "$f_no_pref_publisher" "global"
-fi
-
-vlog "Preferred global publisher: $gz_publisher_pref"
-
 #
 # Try to find the "entire" incorporation's FMRI in the gz.
 #
@@ -600,60 +391,7 @@ fi
 
 log "$m_updating"
 
-#
-# The NGZ publishers must be a superset of the GZ publisher. Process
-# the GZ publishers and make the NGZ publishers match them.
-# You can't remove a preferred publisher, so temporarily create
-# a preferred publisher
-RANDOM=$$
-
-ZNAME=za$RANDOM
-
-LC_ALL=C $PKG set-publisher --no-refresh -P -g http://localhost:10000 $ZNAME
-for key in ${!gz_publishers[*]}; do
-	typeset newloc=""
-
-	args=$(print_publisher_pkg_defn gz_publishers $key)
-
-	# Copy credentials from global zone.
-	safe_dir var
-	safe_dir var/pkg
-
-	eval publisher="${gz_publishers[$key]}"
-	if [[ ${publisher.keyfile} != "None" || \
-	    ${publisher.certfile} != "None" ]]; then
-		if [[ -e $ZONEROOT/$KEYDIR ]]; then
-			safe_dir $KEYDIR
-		else
-			mkdir -m 755 $ZONEROOT/$KEYDIR
-		fi
-	fi
-
-	if [[ ${publisher.keyfile} != "None" ]]; then
-		relnewloc="$KEYDIR/$(basename ${publisher.keyfile})"
-		newloc="$ZONEROOT/$relnewloc"
-		safe_copy ${publisher.keyfile} $newloc
-		chmod 644 $newloc
-		chown -h root:root $newloc
-		args="$args -k $relnewloc"
-	fi
-	if [[ ${publisher.certfile} != "None" ]]; then
-		relnewloc="$KEYDIR/$(basename ${publisher.certfile})"
-		newloc="$ZONEROOT/$relnewloc"
-		safe_copy ${publisher.certfile} $newloc
-		chmod 644 $newloc
-		chown -h root:root $newloc
-		args="$args -c $relnewloc"
-	fi
-	LC_ALL=C $PKG unset-publisher $key >/dev/null 2>&1
-	LC_ALL=C $PKG set-publisher $args $key
-	
-done
-
-#
-# Now remove our temporary publisher
-#
-LC_ALL=C $PKG unset-publisher $ZNAME
+LC_ALL=C $PKG copy-publishers-from $GZ_IMAGE
 
 #
 # Bring the ngz entire incorporation into sync with the gz as follows:

--- a/src/brand/pkgcreatezone
+++ b/src/brand/pkgcreatezone
@@ -38,29 +38,18 @@ export PKG_IMAGE
 
 f_a_obs=$(gettext "-a publisher=uri option is obsolete, use -P instead.")
 f_pkg5_missing=$(gettext "pkg(5) does not seem to be present on this system.\n")
-f_no_pref_publisher=$(gettext "Unable to get global zone preferred publisher information, and none was supplied.\nYou must specify one using the -P option.")
-f_key_file=$(gettext "Key file not allowed without -P")
-f_cert_file=$(gettext "Cert file not allowed without -P")
 f_img=$(gettext "failed to create image\n")
 f_pkg=$(gettext "failed to install package\n")
 f_interrupted=$(gettext "Installation cancelled due to interrupt.\n")
 f_bad_publisher=$(gettext "Syntax error in publisher information.")
 f_no_entire_in_pref=$(gettext "Unable to locate the incorporation '%s' in the preferred publisher '%s'.\nUse -P to supply a publisher which contains this package.\n")
-f_key_prop=$(gettext "Unable to propagate key %s to %s")
-f_cert_prop=$(gettext "Unable to propagate cert %s to %s")
-f_get_secinfo=$(gettext "Failed to get key/cert information for publisher %s")
-f_nosuch_key=$(gettext "Failed to find key %s")
-f_nosuch_cert=$(gettext "Failed to find cert %s")
 
 m_publisher=$(gettext   "   Publisher: Using %s (%s).")
 m_cache=$(gettext       "       Cache: Using %s.")
 m_image=$(gettext       "       Image: Preparing at %s.")
-m_incorp=$(gettext      "Sanity Check: Looking for 'entire' incorporation.\n")
-m_key_prop=$(gettext    " Credentials: Propagating %s\n")
-m_cert_prop=$(gettext   " Credentials: Propagating %s\n")
-m_core=$(gettext	"  Installing: Packages (output follows)\n")
+m_incorp=$(gettext      "Sanity Check: Looking for 'entire' incorporation.")
+m_core=$(gettext	"  Installing: Packages (output follows)")
 m_smf=$(gettext		" Postinstall: Copying SMF seed repository ...")
-m_more_brokenness=$(gettext " Postinstall: Applying workarounds.")
 m_mannote=$(gettext     "        Note: Man pages can be obtained by installing pkg:/system/manual")
 
 m_usage=$(gettext "\n        install [-h]\n        install [-c certificate_file] [-k key_file] [-P publisher=uri]\n                [-e extrapkg [...]]\n        install {-a archive|-d path} {-p|-u} [-s|-v]")
@@ -79,7 +68,7 @@ extra_packages=""
 ZONENAME=""
 ZONEPATH=""
 pub_and_origins=""
-pub_and_mirrors=""
+copy_from_gz=
 
 # Setup i18n output
 TEXTDOMAIN="SUNW_OST_OSCMD"
@@ -175,121 +164,6 @@ if [[ -z $install_archive && -z $source_dir ]]; then
 fi
 
 #
-# If the user didn't give us a publisher, and there's a preferred publisher set
-# for the system, set that as the default.
-#
-propagate_secinfo=
-propagate_extra=
-if [[ -z $pub_and_origins ]]; then
-	if [[ $keyfile != "None" ]]; then
-		fail_usage "$f_key_file"
-	fi
-	if [[ $certfile != "None" ]]; then
-		fail_usage "$f_cert_file"
-	fi
-
-	# Look for a preferred online origin.
-	# tpub_and_origins=$(get_publisher_urls preferred origin)
-
-	# XXX there is no concept of preferred publisher in newer pkg5
-	tpub_and_origins=$(get_publisher_urls all origin|head -1)
-
-	[[ $? -eq 0 && -n $tpub_and_origins ]] && \
-	    pub_and_origins="$tpub_and_origins"
-
-	# Get preferred mirror information as well if the above succeeded.
-	if [[ -n "$tpub_and_origins" ]]; then
-		# tpub_and_mirrors=$(get_publisher_urls preferred mirror)
-		# XXX there is no concept of preferred publisher in newer pkg5
-		echo $tpub_and_mirrors|IFS="=" read preferred_publisher pub_urls
-		tpub_and_mirrors=$(get_publisher_urls all mirror|grep ^$preferred_publisher=)
-		[[ $? -eq 0 && -n $tpub_and_mirrors ]] && \
-		    pub_and_mirrors="$tpub_and_mirrors"
-	fi
-
-	# Note that later we need to propagate key & cert.
-	propagate_secinfo=1
-
-	#
-	# since the user didn't specify a publisher, propagate all the
-	# publishers that don't have a key.
-	#
-	propagate_extra=1
-fi
-[[ -z $pub_and_origins ]] && fail_usage "$f_no_pref_publisher"
-
-# find the remaining publishers in the global zone
-publishers_extra_origins=""
-publishers_extra_mirrors=""
-
-if [[ -n $propagate_extra ]]; then
-
-	# If cert and key information are ever allowed at the origin or
-	# mirror level, then this will have to be changed.
-	# XXX there is no concept of preferred publisher in newer pkg5
-	get_publisher_urls all origin | awk 'BEGIN { getline } { print }' | \
-	    while IFS="=" read pub pub_urls; do
-		if [[ "$pub_urls" != "None" ]]; then
-			# skip extra publishers that need a key/cert
-			[[ "`get_pub_secinfo $pub`" != "None None" ]] && \
-			    continue
-		else
-			pub_urls=""
-		fi
-
-		if [[ -z "$publishers_extra_origins" ]]; then
-			publishers_extra_origins="$pub=$pub_urls"
-		else
-			publishers_extra_origins=$(printf "%s\n%s" \
-			    "$publishers_extra_origins" \
-			    "$pub=$pub_urls")
-		fi
-	done
-
-	get_publisher_urls all mirror | grep -v ^$preferred_publisher= | \
-	    while IFS="=" read pub pub_urls; do
-		# skip extra publishers that need a key/cert
-		[[ "`get_pub_secinfo $pub`" != "None None" ]] && \
-		    continue
-
-		if [[ -z "$publishers_extra_mirrors" ]]; then
-			publishers_extra_mirrors="$pub=$pub_urls"
-		else
-			publishers_extra_mirrors=$(printf "%s\n%s" \
-			    "$publishers_extra_mirrors" \
-			    "$pub=$pub_urls")
-		fi
-	done
-fi
-
-#
-# Crack pub=url into two pieces.
-#
-echo $pub_and_origins | IFS="=" read publisher pub_origins
-if [[ -z $publisher || -z $pub_origins ]]; then
-	fail_usage "$f_bad_publisher"
-fi
-echo $pub_and_mirrors | IFS="=" read ignored pub_mirrors
-
-if [[ -n $propagate_secinfo ]]; then
-	#
-	# Get the global zone's cert and key (if any) so that we can propagate
-	# them into the new image.
-	#
-	get_pub_secinfo $publisher | read keyfile certfile
-	if [[ $? -ne 0 ]]; then
-		fail_usage "$f_get_secinfo" $publisher
-	fi
-fi
-#
-# Do some sanity checks on key and cert.
-#
-[[ $keyfile != "None" && ! -f $keyfile ]] && \
-    fail_usage "$f_nosuch_key" $keyfile
-[[ $certfile != "None" && ! -f $certfile ]] && \
-    fail_usage "$f_nosuch_cert" $certfile
-
-#
 # Look for the 'entire' incorporation's FMRI in the current image; due to users
 # doing weird machinations with their publishers, we strip off the publisher
 # from the FMRI if it is present.
@@ -297,6 +171,38 @@ fi
 # can install pre-release development bits for testing purposes.
 #
 entire_fmri=$(get_entire_incorp)
+
+#
+# If we found an "entire" incorporation in the current image, then
+# check to see if the user's choice of preferred publisher contains the
+# version of the 'entire' incorporation needed.  This helps us to prevent
+# mishaps in the event the user selected some weirdo publisher as their
+# preferred one, or passed a preferred pub on the command line which doesn't
+# have a suitable 'entire' in it.
+#
+if [[ -n $entire_fmri ]]; then
+	# If we have a user-specified publisher and origin from -P, consult
+	# only that one; otherwise any origin from the first publisher will do.
+	list_origin=
+	if [[ -n "$pub_and_origins" ]]; then
+		#
+		# Crack pub=url into two pieces.
+		#
+		echo $pub_and_origins | IFS="=" read publisher pub_origins
+		if [[ -z $publisher || -z $pub_origins ]]; then
+			fail_usage "$f_bad_publisher"
+		fi
+		list_origin="-g $pub_origins"
+	else
+		$PKG publisher -HPn -F tsv | cut -f1 | read publisher
+	fi
+	printf "$m_incorp\n"
+	LC_ALL=C $PKG list $list_origin -af pkg://$publisher/$entire_fmri \
+		> /dev/null 2>&1
+	if [[ $? -ne 0 ]]; then
+		fail_fatal "$f_no_entire_in_pref" $entire_fmri $publisher
+	fi
+fi
 
 #
 # Before installing the zone, set up ZFS dataset hierarchy for the zone root
@@ -319,91 +225,18 @@ if [[ -n $install_archive || -n $source_dir ]]; then
 	exit $ZONE_SUBPROC_OK
 fi
 
-# Display preferred publisher origin and mirror information.
-printf "$m_publisher\n" $publisher "$pub_origins $pub_mirrors"
-
-# Display extra publisher origin and mirror information.  This does mean that
-# the extras have to be displayed twice to show mirror information.
-if [[ -n "$publishers_extra_origins" ]]; then
-	echo "$publishers_extra_origins" | while IFS="=" read pub pub_urls; do
-		printf "$m_publisher\n" $pub "$pub_urls"
-	done
-	if [[ -n "$publishers_extra_mirrors" ]]; then
-		echo "$publishers_extra_mirrors" | while IFS="=" read pub pub_urls; do
-			printf "$m_publisher\n" $pub "$pub_urls"
-		done
-	fi
-fi
-
 printf "$m_image\n" $ZONEROOT
 
-#
-# We copy the credentials from the global zone into the new image
-# we're about to create.
-#
-if [[ $keyfile != "None" ]]; then
-	newkeylocation="$KEYDIR/$(basename $keyfile)"
-	secinfo="$secinfo -k $newkeylocation"
-	printf "$m_key_prop\n" $(basename $keyfile)
-	mkdir -p -m 755 $ZONEROOT/$KEYDIR || fail_fatal "$f_key_prop"
-	cp $keyfile $ZONEROOT/$newkeylocation || fail_fatal "$f_key_prop"
-	chmod 644 $ZONEROOT/$newkeylocation
-	chown -h root:root $ZONEROOT/$newkeylocation
-fi
-if [[ $certfile != "None" ]]; then
-	newcertlocation="$KEYDIR/$(basename $certfile)"
-	secinfo="$secinfo -c $newcertlocation"
-	printf "$m_cert_prop\n" $(basename $certfile)
-	mkdir -p -m 755 $ZONEROOT/$KEYDIR || fail_fatal "$f_cert_prop"
-	cp $certfile $ZONEROOT/$newcertlocation || fail_fatal "$f_cert_prop"
-	chmod 644 $ZONEROOT/$newcertlocation
-	chown -h root:root $ZONEROOT/$newcertlocation
-fi
-
-#
-# Regrettably, since we already copied the key information into place,
-# we must pass the -f (force) option to image-create, since it thinks that
-# something must be wrong, as the image exists.
-#
-pub_first_origin=""
-pub_add_origins=""
-for origin in $pub_origins; do
-	if [[ -z "$pub_first_origin" ]]; then
-		# The first origin is semi-special in that the publisher
-		# argument to image-create requires it to be specified
-		# by itself and then any additional origins after that.
-		# Technically, image-create doesn't care if you specify
-		# the first one again using -g, but there's no point in
-		# doing so.
-		pub_first_origin=$origin
-		continue
-	fi
-	pub_add_origins="${pub_add_origins}-g $origin "
-done
-
-pub_add_mirrors=""
-for mirror in $pub_mirrors; do
-	pub_add_mirrors="${pub_add_mirrors}-m $mirror "
-done
-
-#
-# The image is created with --no-refresh so that all of the publisher
-# configuration can be put into place first before attempting to retrieve
-# and build catalog information.  This substantially reduces the amount of
-# time needed to create a zone.
-#
-LC_ALL=C $PKG image-create -f --no-refresh --zone --full \
-    -p $publisher=$pub_first_origin $pub_add_origins $pub_add_mirrors $secinfo \
-    $ZONEROOT || fail_incomplete "$f_img"
-
-# Retrieve publisher attributes and update our new publisher
-attrs=$(get_publisher_attr_args $publisher "origin")
-
-# Get the signature policy from the global zone.  This code assumes
-# specific output ( "signature-policy = <policy>"  or empty-string).
-sigpol=$($PKG publisher $publisher | grep signature-policy | sed 's/ = /=/')
-if [ "$sigpol" != "" ]; then
-	sigpol="--set-property $sigpol"
+# If we have a publisher specified by -P, pass it to image-create and use no
+# other publishers. Otherwise, use all of the publishers from the GZ.
+if [[ -n $pub_and_origins ]]; then
+	LC_ALL=C $PKG image-create --zone --full -p $pub_and_origins \
+	    $ZONEROOT \ || fail_incomplete "$f_img"
+else
+	LC_ALL=C $PKG image-create --zone --full $ZONEROOT \
+	    || fail_incomplete "$f_img"
+	LC_ALL=C $PKG -R $ZONEROOT copy-publishers-from $GZ_IMAGE \
+	    || fail_incomplete "$f_img"
 fi
 
 # Change the value of PKG_IMAGE so that future PKG operation will work
@@ -412,94 +245,15 @@ fi
 PKG_IMAGE="$ZONEROOT"
 export PKG_IMAGE
 
-# --no-refresh is used here so that update operations can be
-# coalesced.
-# Update our new publisher
-LC_ALL=C $PKG set-publisher --no-refresh $sigpol $attrs $publisher \
-    || fail_incomplete "$f_img"
-
-# add extra publishers
-# If cert and key information are ever allowed at the origin or
-# mirror level, then this will have to be changed.
-if [[ -n "$publishers_extra_origins" ]]; then
-	echo "$publishers_extra_origins" | while IFS="=" read pub pub_urls; do
-		pub_prefix=$pub
-		pub_add_origins=""
-		for origin in $pub_urls; do
-			pub_add_origins="${pub_add_origins}-g $origin "
-		done
-
-		# Retrieve publisher attributes. Since we are retrieving
-		# these attributes from the GLOBAL zone, we must reset
-		# PKG_IMAGE temporarily
-		SAVE_PKG_IMAGE=$PKG_IMAGE
-		PKG_IMAGE=$GZ_IMAGE
-		export PKG_IMAGE
-		attrs=$(get_publisher_attr_args $pub_prefix "origin")
-		# Now restore the save PKG_IMAGE value
-		PKG_IMAGE=$SAVE_PKG_IMAGE
-		export PKG_IMAGE
-		# --no-refresh is used here so that update operations can be
-		# coalesced.
-		LC_ALL=C $PKG set-publisher --no-refresh $attrs \
-                    ${pub_add_origins}${pub_prefix} || fail_incomplete "$f_img"
-	done
-
-	if [[ -n "$publishers_extra_mirrors" ]]; then
-		echo "$publishers_extra_mirrors" | \
-		    while IFS="=" read pub pub_urls; do
-			pub_prefix=$pub
-			pub_add_mirrors=""
-			for mirror in $pub_urls; do
-				pub_add_mirrors="${pub_add_mirrors}-m $mirror "
-			done
-
-			# Retrieve publisher attributes. Since we are retrieving
-			# these attributes from the GLOBAL zone, we must reset
-			# PKG_IMAGE temporarily
-			SAVE_PKG_IMAGE=$PKG_IMAGE
-			PKG_IMAGE=$GZ_IMAGE
-			export PKG_IMAGE
-			attrs=$(get_publisher_attr_args $pub_prefix "mirror")
-			PKG_IMAGE=$SAVE_PKG_IMAGE
-			export PKG_IMAGE
-			# --no-refresh is used here so that update operations
-			# can be coalesced.
-			LC_ALL=C $PKG set-publisher --no-refresh $attrs \
-			    ${pub_add_mirrors}${pub_prefix} || \
-			    fail_incomplete "$f_img"
-		done
-	fi
-fi
-
-# Now that all of the publisher configurations are in place, attempt a refresh.
-# If this fails, assume the image is incomplete.
-LC_ALL=C $PKG refresh || fail_incomplete "$f_img"
+LC_ALL=C $PKG publisher -Hn -F tsv | cut -f1,7 | while read pub url; do
+	[[ -z "$publisher" ]] && publisher="$pub"
+	printf "$m_publisher\n" $pub $url
+done
 
 if [[ -f /var/pkg/pkg5.image && -d /var/pkg/publisher ]]; then
 	PKG_CACHEROOT=/var/pkg/publisher
 	export PKG_CACHEROOT
 	printf "$m_cache\n" $PKG_CACHEROOT
-fi
-
-#
-# If we found an "entire" incorporation in the current image, then
-# check to see if the user's choice of preferred publisher contains the
-# version of the 'entire' incorporation needed.  This helps us to prevent
-# mishaps in the event the user selected some weirdo publisher as their
-# preferred one, or passed a preferred pub on the command line which doesn't
-# have a suitable 'entire' in it.
-#
-# n.b. it would be nice to do this before we provision the zfs dataset, etc.
-# but since the publisher specified by the user might not be known to
-# the system, we can't do this test without first configuring the image.
-#
-if [[ -n $entire_fmri ]]; then
-	printf "$m_incorp\n"
-	LC_ALL=C $PKG list -af pkg://$publisher/$entire_fmri > /dev/null 2>&1
-	if [[ $? -ne 0 ]]; then
-		fail_fatal "$f_no_entire_in_pref" $entire_fmri $publisher
-	fi
 fi
 
 printf "$m_core\n"

--- a/src/client.py
+++ b/src/client.py
@@ -333,6 +333,7 @@ def usage(usage_error=None, cmd=None, retcode=EXIT_BADOPT, full=False):
             "[-nvq] [--accept] [--licenses] [--no-index] [--no-refresh]\n"
             "            [--no-parent-sync] [--no-pkg-updates]\n"
             "            [--linked-md-only] <propname>=<propvalue> ...")
+        priv_usage["copy-publishers-from"] = _("<dir>")
 
         def print_cmds(cmd_list, cmd_dic):
                 for cmd in cmd_list:
@@ -4090,6 +4091,25 @@ assistance."""))
         # each refresh requires a client image state rebuild.
         return __refresh(api_inst, added + updated)
 
+def copy_publishers_from(api_inst, args):
+        """pkg copy-publishers-from <dir>"""
+        opts, pargs = getopt.getopt(args, "")
+        if len(pargs) != 1:
+                usage(_("directory to copy from must be specified"),
+                      cmd="copy-publishers-from")
+        src_api_inst = __api_alloc(pargs[0], True, False)
+        if not src_api_inst:
+                return EXIT_OOPS
+        for n, pub in enumerate(src_api_inst.get_publishers()):
+                search_first = True if n == 0 else False
+                if api_inst.has_publisher(prefix=pub.prefix, alias=pub.prefix):
+                        api_inst.remove_publisher(prefix=pub.prefix,
+                                                  alias=pub.prefix)
+                api_inst.add_publisher(pub, refresh_allowed=False,
+                                       search_first=search_first)
+        api_inst.refresh()
+        return EXIT_OK
+
 def _add_update_pub(api_inst, prefix, pub=None, disable=None, sticky=None,
     origin_uri=None, add_mirrors=EmptyI, remove_mirrors=EmptyI,
     add_origins=EmptyI, remove_origins=EmptyI, ssl_cert=None, ssl_key=None,
@@ -5964,6 +5984,7 @@ cmds = {
     "change-facet"          : [change_facet],
     "change-variant"        : [change_variant],
     "contents"              : [list_contents],
+    "copy-publishers-from"  : [copy_publishers_from, 1],
     "detach-linked"         : [detach_linked, 0],
     "facet"                 : [list_facet],
     "fix"                   : [fix_image],


### PR DESCRIPTION
This fixes #2 and greatly simplifies the ipkg zone creation and attach scripts. I tested that both actions still work:

```
hipster ~/pkg5 % pfexec zoneadm -z foo install
A ZFS file system has been created for this zone.
Sanity Check: Looking for 'entire' incorporation.
       Image: Preparing at /zones/foo/root.

   Publisher: Using omnios (http://pkg.omniti.com/omnios/bloody/).
   Publisher: Using on-nightly (file:///ws/illumos-omnios/packages/i386/nightly/repo.redist/).
   Publisher: Using niksula.hut.fi (http://pkg.niksula.hut.fi/).
       Cache: Using /var/pkg/publisher.
  Installing: Packages (output follows)
Packages to install: 386
Mediators to change:   2
 Services to change:   4

DOWNLOAD                                PKGS         FILES    XFER (MB)   SPEED
Completed                            386/386   36374/36374  324.0/324.0  753k/s

PHASE                                          ITEMS
Installing new actions                   59619/59619
Updating package state database                 Done 
Updating package cache                           0/0 
Updating image state                            Done 
Creating fast lookup database                   Done 

        Note: Man pages can be obtained by installing pkg:/system/manual
 Postinstall: Copying SMF seed repository ... done.
        Done: Installation completed in 466.477 seconds.

  Next Steps: Boot the zone, then log into the zone console (zlogin -C)
              to complete the configuration process.
hipster ~/pkg5 % pfexec pkg -R /zones/foo/root list -v -af entire
FMRI                                                                         IFO
pkg://omnios/entire@11-0.151017:20151211T141541Z                             i--
pkg://omnios/entire@11-0.151017:20151211T033227Z                             ---
pkg://omnios/entire@11-0.151017:20151106T034315Z                             ---
hipster ~/pkg5 % pfexec zoneadm -z foo detach
hipster ~/pkg5 % pfexec pkg -R /zones/foo/root update entire@11-0.151017:20151106T034315Z 
Packages to update: 1

PHASE                                          ITEMS
Removing old actions                             1/1
Installing new actions                           1/1
Updating modified actions                        1/1
Updating package state database                 Done 
Updating package cache                           1/1 
Updating image state                            Done 
Creating fast lookup database                   Done 
hipster ~/pkg5 % pfexec zoneadm -z foo attach -u
Log File: /var/tmp/foo.attach_log.50aW5L
               Attach Path: /zones/foo/root
        Attach ZFS Dataset: rpool/zones/foo/ROOT/zbe

                Installing: Using pre-existing data in zonepath
       Global zone version: entire@11-0.151017:20151211T141541Z
   Non-Global zone version: entire@11-0.151017:20151106T034315Z
                     Cache: Using /var/pkg/publisher.
  Updating non-global zone: Output follows
Packages to update: 1

PHASE                                          ITEMS
Removing old actions                             1/1
Installing new actions                           1/1
Updating modified actions                        1/1
Updating package state database                 Done 
Updating package cache                           1/1 
Updating image state                            Done 
Creating fast lookup database                   Done 

  Updating non-global zone: Zone updated.
                    Result: Attach Succeeded.
```

and that the signature-policy and approved CAs are actually copied:

```
hipster ~/pkg5 % pfexec pkg -R /zones/foo/root publisher niksula.hut.fi

            Publisher: niksula.hut.fi
                Alias: 
           Origin URI: http://pkg.niksula.hut.fi/
              SSL Key: None
             SSL Cert: None
          Client UUID: 2c8248f2-afc5-11e5-b8fe-82082085168c
      Catalog Updated: Tue Dec 22 15:55:43 2015
         Approved CAs: 5b14cb37b522013079016a6867c65e491a57efb3
              Enabled: Yes
hipster ~/pkg5 % pfexec pkg -R /zones/foo/root publisher omnios

            Publisher: omnios
                Alias: 
           Origin URI: http://pkg.omniti.com/omnios/bloody/
              SSL Key: None
             SSL Cert: None
          Client UUID: eac58714-5b26-11e5-9665-802590aba566
      Catalog Updated: Fri Dec 11 14:18:34 2015
              Enabled: Yes
           Properties:
                       signature-policy = verify
```
